### PR TITLE
fix(infra): resolve XML AccessDenied errors by appending index.html t…

### DIFF
--- a/infra/live/cloudfront.tf
+++ b/infra/live/cloudfront.tf
@@ -30,7 +30,7 @@ resource "aws_cloudfront_distribution" "portfolio" {
 
     function_association {
       event_type   = "viewer-request"
-      function_arn = var.cloudfront_function_arn
+      function_arn = aws_cloudfront_function.url_rewrite.arn
     }
   }
 

--- a/infra/live/functions.tf
+++ b/infra/live/functions.tf
@@ -1,0 +1,24 @@
+resource "aws_cloudfront_function" "url_rewrite" {
+  name    = "mpa-url-rewrite"
+  runtime = "cloudfront-js-2.0"
+  comment = "Suporte a Pretty URLs para Astro SSG no S3 (OAC)"
+  publish = true
+  code    = <<EOF
+function handler(event) {
+    const request = event.request;
+    const currentPath = request.uri;
+    
+    if (currentPath.indexOf('.') !== -1) {
+        return request;
+    }
+    
+    if (currentPath.endsWith('/')) {
+        request.uri += 'index.html';
+        return request;
+    }
+
+    request.uri += '/index.html';
+    return request;
+}
+EOF
+}


### PR DESCRIPTION
- Resolve XML AccessDenied errors by appending 'index.html' to directory URIs.
- Implement 'aws_cloudfront_function' in Terraform for declarative management.
- Use 'cloudfront-js-2.0' runtime for modern ES6 syntax and early return pattern.
- Update CloudFront distribution to link directly to the managed function resource.
- Improve variable naming and code legibility within the URL rewrite logic.