### PR TITLE
feat(terraform): add isolated staging environment foundation

### DIFF
--- a/infra/environments/production/site_stack.tf
+++ b/infra/environments/production/site_stack.tf
@@ -1,5 +1,10 @@
+data "aws_route53_zone" "authoritative_public" {
+  name         = "leandrodeobarbosa.dev."
+  private_zone = false
+}
+
 locals {
-  route53_zone_id               = "Z0651036AF6S0HILTEF4"
+  route53_zone_id               = data.aws_route53_zone.authoritative_public.zone_id
   enable_www_alias              = true
   manage_certificate_validation = false
   cloudfront_function_name      = "mpa-url-rewrite"

--- a/infra/environments/production/site_stack.tf
+++ b/infra/environments/production/site_stack.tf
@@ -1,3 +1,11 @@
+locals {
+  route53_zone_id               = "Z0651036AF6S0HILTEF4"
+  enable_www_alias              = true
+  manage_certificate_validation = false
+  cloudfront_function_name      = "mpa-url-rewrite"
+  origin_access_control_name    = "oac-leandrodeobarbosa-portfolio.s3.us-east-1.amazona-mmuskrtrsu5"
+}
+
 module "site_stack" {
   source = "../../modules/site_stack"
 
@@ -8,4 +16,9 @@ module "site_stack" {
   noncurrent_version_expiration_days = var.noncurrent_version_expiration_days
   abort_multipart_days               = var.abort_multipart_days
   domain_name                        = var.domain_name
+  route53_zone_id                    = local.route53_zone_id
+  enable_www_alias                   = local.enable_www_alias
+  manage_certificate_validation      = local.manage_certificate_validation
+  cloudfront_function_name           = local.cloudfront_function_name
+  origin_access_control_name         = local.origin_access_control_name
 }

--- a/infra/environments/staging/.terraform.lock.hcl
+++ b/infra/environments/staging/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.37.0"
+  constraints = "6.37.0"
+  hashes = [
+    "h1:w3z/TApcKD3b/aMZoZZKSxOld4xw+gEtQ1ka6C1UN+4=",
+    "zh:0427fadb719ed5a32feb09f047539d2348e659056f3b8a8589d34d8f0a95be7a",
+    "zh:3891c670674aba2125a7ac6d4348cde43646b1b46ce6f829e6f4724091bc0dcd",
+    "zh:632cb24b7b5790b730b33bcbe9f1a7b75f2644fb52f9d6aaafb0249c9e7601d2",
+    "zh:6e96ed1f824c2efa9de5b7c22ab3715624ba34c28564a06e9a15e71bc3d3a30b",
+    "zh:7b8fd86907b659bc45f4a3f42c3c0ccc66925a74e265b01e9e66242c0b2cafef",
+    "zh:81f9a587deddef4dfcc2101c54ec28a3a554056837f68ebb920c83fe8327b16f",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a9a38a67cb98d690fec951ec3e133b6836279629db2ed3a0ebf97a5bea58674f",
+    "zh:b18f60d62e4bd4d466077e09c39259d1a85355f0f00b801fe8aedbc50193d357",
+    "zh:b7a51bc0faf60d17043b4df1d1b7bb55129eaa4bdeb65ff55f5b00b9b8fee9f7",
+    "zh:c28c42f91ca3a6b65b3fd3ed6e891fc0fc28d0cb5ab65dea65eda8eec5cea5f3",
+    "zh:d895ddc04280ed26b6ca64ca05b78caaa7b72c8e167af4093545efbc608d5482",
+    "zh:f4a56f5157009ef160fbd79105078fe675df479cb73c1b7e1fea2741403a0b67",
+    "zh:f547d6ca371b96fec97b972fc0c93bcfc23d58e34a9da215b94e9d2aa170fb77",
+    "zh:f7b0a3cd4adadd3f4b9609a54e651ed5eafa22c196ab229042fc1d0aa0ab8f3a",
+  ]
+}

--- a/infra/environments/staging/backend.tf
+++ b/infra/environments/staging/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "leandro-tfstate-bootstrap"
+    key            = "environments/staging/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-lock"
+    encrypt        = true
+  }
+}

--- a/infra/environments/staging/outputs.tf
+++ b/infra/environments/staging/outputs.tf
@@ -1,0 +1,3 @@
+output "website_url" {
+  value = module.site_stack.website_url
+}

--- a/infra/environments/staging/provider.tf
+++ b/infra/environments/staging/provider.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.37.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = var.project_name
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      Owner       = "leandro"
+    }
+  }
+}

--- a/infra/environments/staging/site_stack.tf
+++ b/infra/environments/staging/site_stack.tf
@@ -1,0 +1,16 @@
+module "site_stack" {
+  source = "../../modules/site_stack"
+
+  aws_region                         = var.aws_region
+  project_name                       = var.project_name
+  environment                        = var.environment
+  bucket_name                        = var.bucket_name
+  noncurrent_version_expiration_days = var.noncurrent_version_expiration_days
+  abort_multipart_days               = var.abort_multipart_days
+  domain_name                        = var.domain_name
+  route53_zone_id                    = var.route53_zone_id
+  enable_www_alias                   = var.enable_www_alias
+  manage_certificate_validation      = var.manage_certificate_validation
+  cloudfront_function_name           = var.cloudfront_function_name
+  origin_access_control_name         = var.origin_access_control_name
+}

--- a/infra/environments/staging/site_stack.tf
+++ b/infra/environments/staging/site_stack.tf
@@ -1,3 +1,11 @@
+locals {
+  route53_zone_id               = "Z0651036AF6S0HILTEF4"
+  enable_www_alias              = false
+  manage_certificate_validation = true
+  cloudfront_function_name      = "portfolio-staging-url-rewrite"
+  origin_access_control_name    = "oac-leandrodeobarbosa-portfolio-staging.s3.us-east-1"
+}
+
 module "site_stack" {
   source = "../../modules/site_stack"
 
@@ -8,9 +16,9 @@ module "site_stack" {
   noncurrent_version_expiration_days = var.noncurrent_version_expiration_days
   abort_multipart_days               = var.abort_multipart_days
   domain_name                        = var.domain_name
-  route53_zone_id                    = var.route53_zone_id
-  enable_www_alias                   = var.enable_www_alias
-  manage_certificate_validation      = var.manage_certificate_validation
-  cloudfront_function_name           = var.cloudfront_function_name
-  origin_access_control_name         = var.origin_access_control_name
+  route53_zone_id                    = local.route53_zone_id
+  enable_www_alias                   = local.enable_www_alias
+  manage_certificate_validation      = local.manage_certificate_validation
+  cloudfront_function_name           = local.cloudfront_function_name
+  origin_access_control_name         = local.origin_access_control_name
 }

--- a/infra/environments/staging/site_stack.tf
+++ b/infra/environments/staging/site_stack.tf
@@ -1,5 +1,10 @@
+data "aws_route53_zone" "authoritative_public" {
+  name         = "leandrodeobarbosa.dev."
+  private_zone = false
+}
+
 locals {
-  route53_zone_id               = "Z0651036AF6S0HILTEF4"
+  route53_zone_id               = data.aws_route53_zone.authoritative_public.zone_id
   enable_www_alias              = false
   manage_certificate_validation = true
   cloudfront_function_name      = "portfolio-staging-url-rewrite"

--- a/infra/environments/staging/variables.tf
+++ b/infra/environments/staging/variables.tf
@@ -1,6 +1,7 @@
 variable "aws_region" {
   description = "Região AWS"
   type        = string
+  default     = "us-east-1"
 }
 
 variable "project_name" {
@@ -21,11 +22,13 @@ variable "bucket_name" {
 variable "noncurrent_version_expiration_days" {
   description = "Dias para expirar versões antigas"
   type        = number
+  default     = 30
 }
 
 variable "abort_multipart_days" {
   description = "Dias para abortar uploads incompletos"
   type        = number
+  default     = 7
 }
 
 variable "domain_name" {
@@ -36,29 +39,24 @@ variable "domain_name" {
 variable "route53_zone_id" {
   description = "Zone ID do Route53 a ser usado pelos registros do site"
   type        = string
-  default     = null
 }
 
 variable "enable_www_alias" {
   description = "Habilita aliases e registros DNS para o subdomínio www"
   type        = bool
-  default     = true
 }
 
 variable "manage_certificate_validation" {
   description = "Gerencia a validação DNS do certificado ACM via Terraform"
   type        = bool
-  default     = false
 }
 
 variable "cloudfront_function_name" {
   description = "Nome da CloudFront Function de rewrite"
   type        = string
-  default     = "mpa-url-rewrite"
 }
 
 variable "origin_access_control_name" {
   description = "Nome do Origin Access Control do CloudFront"
   type        = string
-  default     = "oac-leandrodeobarbosa-portfolio.s3.us-east-1.amazona-mmuskrtrsu5"
 }

--- a/infra/environments/staging/variables.tf
+++ b/infra/environments/staging/variables.tf
@@ -35,28 +35,3 @@ variable "domain_name" {
   description = "Domínio principal do certificado"
   type        = string
 }
-
-variable "route53_zone_id" {
-  description = "Zone ID do Route53 a ser usado pelos registros do site"
-  type        = string
-}
-
-variable "enable_www_alias" {
-  description = "Habilita aliases e registros DNS para o subdomínio www"
-  type        = bool
-}
-
-variable "manage_certificate_validation" {
-  description = "Gerencia a validação DNS do certificado ACM via Terraform"
-  type        = bool
-}
-
-variable "cloudfront_function_name" {
-  description = "Nome da CloudFront Function de rewrite"
-  type        = string
-}
-
-variable "origin_access_control_name" {
-  description = "Nome do Origin Access Control do CloudFront"
-  type        = string
-}

--- a/infra/modules/site_stack/acm.tf
+++ b/infra/modules/site_stack/acm.tf
@@ -7,16 +7,6 @@ locals {
   certificate_sans = var.enable_www_alias ? [
     "www.${var.domain_name}",
   ] : []
-  certificate_validation_domains = toset(local.cloudfront_aliases)
-  certificate_validation_options = {
-    for domain in local.certificate_validation_domains : domain => one([
-      for dvo in aws_acm_certificate.portfolio_certificate.domain_validation_options : {
-        name   = dvo.resource_record_name
-        record = dvo.resource_record_value
-        type   = dvo.resource_record_type
-      } if dvo.domain_name == domain
-    ])
-  }
 }
 
 resource "aws_acm_certificate" "portfolio_certificate" {
@@ -33,21 +23,4 @@ resource "aws_acm_certificate" "portfolio_certificate" {
     Component = "acm"
     Usage     = "cloudfront-ssl"
   }
-}
-
-resource "aws_route53_record" "certificate_validation" {
-  for_each = var.manage_certificate_validation ? local.certificate_validation_domains : toset([])
-
-  zone_id = local.route53_zone_id
-  name    = local.certificate_validation_options[each.value].name
-  type    = local.certificate_validation_options[each.value].type
-  ttl     = 60
-  records = [local.certificate_validation_options[each.value].record]
-}
-
-resource "aws_acm_certificate_validation" "portfolio_certificate" {
-  count = var.manage_certificate_validation ? 1 : 0
-
-  certificate_arn         = aws_acm_certificate.portfolio_certificate.arn
-  validation_record_fqdns = [for record in aws_route53_record.certificate_validation : record.fqdn]
 }

--- a/infra/modules/site_stack/acm.tf
+++ b/infra/modules/site_stack/acm.tf
@@ -1,8 +1,27 @@
+locals {
+  route53_zone_id = var.route53_zone_id != null ? var.route53_zone_id : data.aws_route53_zone.portfolio[0].zone_id
+  cloudfront_aliases = var.enable_www_alias ? [
+    var.domain_name,
+    "www.${var.domain_name}",
+  ] : [var.domain_name]
+  certificate_sans = var.enable_www_alias ? [
+    "www.${var.domain_name}",
+  ] : []
+  certificate_validation_domains = toset(local.cloudfront_aliases)
+  certificate_validation_options = {
+    for domain in local.certificate_validation_domains : domain => one([
+      for dvo in aws_acm_certificate.portfolio_certificate.domain_validation_options : {
+        name   = dvo.resource_record_name
+        record = dvo.resource_record_value
+        type   = dvo.resource_record_type
+      } if dvo.domain_name == domain
+    ])
+  }
+}
+
 resource "aws_acm_certificate" "portfolio_certificate" {
-  domain_name = var.domain_name
-  subject_alternative_names = [
-    "www.${var.domain_name}"
-  ]
+  domain_name               = var.domain_name
+  subject_alternative_names = local.certificate_sans
 
   validation_method = "DNS"
 
@@ -14,4 +33,21 @@ resource "aws_acm_certificate" "portfolio_certificate" {
     Component = "acm"
     Usage     = "cloudfront-ssl"
   }
+}
+
+resource "aws_route53_record" "certificate_validation" {
+  for_each = var.manage_certificate_validation ? local.certificate_validation_domains : toset([])
+
+  zone_id = local.route53_zone_id
+  name    = local.certificate_validation_options[each.value].name
+  type    = local.certificate_validation_options[each.value].type
+  ttl     = 60
+  records = [local.certificate_validation_options[each.value].record]
+}
+
+resource "aws_acm_certificate_validation" "portfolio_certificate" {
+  count = var.manage_certificate_validation ? 1 : 0
+
+  certificate_arn         = aws_acm_certificate.portfolio_certificate.arn
+  validation_record_fqdns = [for record in aws_route53_record.certificate_validation : record.fqdn]
 }

--- a/infra/modules/site_stack/acm_validation.tf
+++ b/infra/modules/site_stack/acm_validation.tf
@@ -1,0 +1,29 @@
+locals {
+  certificate_validation_domains = toset(local.cloudfront_aliases)
+  certificate_validation_records_by_domain = {
+    for domain in local.certificate_validation_domains : domain => one([
+      for domain_validation_option in aws_acm_certificate.portfolio_certificate.domain_validation_options : {
+        name   = domain_validation_option.resource_record_name
+        record = domain_validation_option.resource_record_value
+        type   = domain_validation_option.resource_record_type
+      } if domain_validation_option.domain_name == domain
+    ])
+  }
+}
+
+resource "aws_route53_record" "certificate_validation" {
+  for_each = var.manage_certificate_validation ? local.certificate_validation_domains : toset([])
+
+  zone_id = local.route53_zone_id
+  name    = local.certificate_validation_records_by_domain[each.value].name
+  type    = local.certificate_validation_records_by_domain[each.value].type
+  ttl     = 60
+  records = [local.certificate_validation_records_by_domain[each.value].record]
+}
+
+resource "aws_acm_certificate_validation" "portfolio_certificate" {
+  count = var.manage_certificate_validation ? 1 : 0
+
+  certificate_arn         = aws_acm_certificate.portfolio_certificate.arn
+  validation_record_fqdns = [for record in aws_route53_record.certificate_validation : record.fqdn]
+}

--- a/infra/modules/site_stack/cloudfront.tf
+++ b/infra/modules/site_stack/cloudfront.tf
@@ -6,10 +6,7 @@ resource "aws_cloudfront_distribution" "portfolio" {
   is_ipv6_enabled     = true
   http_version        = "http2"
 
-  aliases = [
-    var.domain_name,
-    "www.${var.domain_name}"
-  ]
+  aliases = local.cloudfront_aliases
 
   origin {
     domain_name = "${var.bucket_name}.s3.${var.aws_region}.amazonaws.com"
@@ -35,7 +32,7 @@ resource "aws_cloudfront_distribution" "portfolio" {
   }
 
   viewer_certificate {
-    acm_certificate_arn      = aws_acm_certificate.portfolio_certificate.arn
+    acm_certificate_arn      = var.manage_certificate_validation ? aws_acm_certificate_validation.portfolio_certificate[0].certificate_arn : aws_acm_certificate.portfolio_certificate.arn
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.2_2021"
   }

--- a/infra/modules/site_stack/functions.tf
+++ b/infra/modules/site_stack/functions.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudfront_function" "url_rewrite" {
-  name    = "mpa-url-rewrite"
+  name    = var.cloudfront_function_name
   runtime = "cloudfront-js-2.0"
   comment = "Suporte a Pretty URLs para Astro SSG no S3 (OAC)"
   publish = true

--- a/infra/modules/site_stack/moved.tf
+++ b/infra/modules/site_stack/moved.tf
@@ -1,0 +1,9 @@
+moved {
+  from = aws_route53_record.www_a
+  to   = aws_route53_record.www_a[0]
+}
+
+moved {
+  from = aws_route53_record.www_aaaa
+  to   = aws_route53_record.www_aaaa[0]
+}

--- a/infra/modules/site_stack/oac.tf
+++ b/infra/modules/site_stack/oac.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudfront_origin_access_control" "portfolio_s3" {
-  name                              = "oac-leandrodeobarbosa-portfolio.s3.us-east-1.amazona-mmuskrtrsu5"
+  name                              = var.origin_access_control_name
   description                       = "Created by CloudFront"
   origin_access_control_origin_type = "s3"
   signing_behavior                  = "always"

--- a/infra/modules/site_stack/outputs.tf
+++ b/infra/modules/site_stack/outputs.tf
@@ -3,5 +3,5 @@ output "website_url" {
 }
 
 output "www_website_url" {
-  value = "https://www.${var.domain_name}"
+  value = var.enable_www_alias ? "https://www.${var.domain_name}" : null
 }

--- a/infra/modules/site_stack/route53.tf
+++ b/infra/modules/site_stack/route53.tf
@@ -1,10 +1,11 @@
 data "aws_route53_zone" "portfolio" {
+  count        = var.route53_zone_id == null ? 1 : 0
   name         = var.domain_name
   private_zone = false
 }
 
 resource "aws_route53_record" "root_a" {
-  zone_id = data.aws_route53_zone.portfolio.zone_id
+  zone_id = local.route53_zone_id
   name    = var.domain_name
   type    = "A"
 
@@ -16,7 +17,7 @@ resource "aws_route53_record" "root_a" {
 }
 
 resource "aws_route53_record" "root_aaaa" {
-  zone_id = data.aws_route53_zone.portfolio.zone_id
+  zone_id = local.route53_zone_id
   name    = var.domain_name
   type    = "AAAA"
 
@@ -28,7 +29,8 @@ resource "aws_route53_record" "root_aaaa" {
 }
 
 resource "aws_route53_record" "www_a" {
-  zone_id = data.aws_route53_zone.portfolio.zone_id
+  count   = var.enable_www_alias ? 1 : 0
+  zone_id = local.route53_zone_id
   name    = "www.${var.domain_name}"
   type    = "A"
 
@@ -40,7 +42,8 @@ resource "aws_route53_record" "www_a" {
 }
 
 resource "aws_route53_record" "www_aaaa" {
-  zone_id = data.aws_route53_zone.portfolio.zone_id
+  count   = var.enable_www_alias ? 1 : 0
+  zone_id = local.route53_zone_id
   name    = "www.${var.domain_name}"
   type    = "AAAA"
 


### PR DESCRIPTION
- add infra/environments/staging as a dedicated root module
- provision staging with isolated remote state and environment-specific naming
- support staging-only domain without www alias
- add ACM DNS validation support for Terraform-managed staging certificates
- keep production convergent and compatible with no-op plans
- import and preserve production email DNS separately from site_stack
- replace hardcoded Route53 zone ids in root modules with declarative lookup
- improve module maintainability by splitting ACM certificate and validation logic