### PR TITLE
chore(ci): make production deployments manual

### DIFF
--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -1,11 +1,7 @@
 name: CD - Application
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "app/**"
-      - "!app/**/*.md"
+  workflow_dispatch:
 
 concurrency:
   group: cd-app-${{github.ref_name}}

--- a/.github/workflows/cd-infra.yml
+++ b/.github/workflows/cd-infra.yml
@@ -1,10 +1,7 @@
 name: CD - Infrastructure
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "infra/**"
+  workflow_dispatch:
 
 concurrency:
   group: cd-infra-${{github.ref_name}}

--- a/.github/workflows/cv-to-s3.yml
+++ b/.github/workflows/cv-to-s3.yml
@@ -1,10 +1,7 @@
 name: Deploy CV
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "app/public/cv/**"
+  workflow_dispatch:
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary

Updates production deployment workflows to run only via manual dispatch.

Staging remains automatically deployed after merges to `main`, while production deployments require an explicit release action and remain protected by the `production` GitHub Environment approval gate.

## Notes

No deployment logic, Terraform resources, backend configuration or staging workflows were changed.