### PR TITLE
chore(ci): split ci gate checks into reusable workflows

### DIFF
--- a/.github/workflows/ci-app-checks.yml
+++ b/.github/workflows/ci-app-checks.yml
@@ -1,0 +1,41 @@
+name: CI App Checks
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-app:
+    name: Validate App
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./app
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        run: npm install -g pnpm@10.30.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: "pnpm"
+          cache-dependency-path: "./app/pnpm-lock.yaml"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run lint
+        run: pnpm lint
+
+      - name: Astro check
+        run: pnpm check
+
+      - name: Build project
+        run: pnpm build

--- a/.github/workflows/ci-cv-checks.yml
+++ b/.github/workflows/ci-cv-checks.yml
@@ -1,0 +1,32 @@
+name: CI CV Checks
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-cv:
+    name: Validate CV
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate CV file
+        run: |
+          set -euo pipefail
+
+          cv_file="app/public/cv/Leandro-Barbosa-DevOps-CV.pdf"
+
+          test -f "$cv_file"
+          test -s "$cv_file"
+
+          case "$cv_file" in
+            *.pdf) ;;
+            *) echo "CV file must be a PDF"; exit 1 ;;
+          esac
+
+          hash="$(sha256sum "$cv_file" | awk '{ print $1 }' | cut -c1-12)"
+          echo "CV hash: $hash"

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -78,99 +78,21 @@ jobs:
 
   validate-app:
     name: Validate App
-    runs-on: ubuntu-latest
     needs: detect-changes
     if: needs.detect-changes.outputs.app_changed == 'true'
-    defaults:
-      run:
-        working-directory: ./app
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        run: npm install -g pnpm@10.30.3
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: "pnpm"
-          cache-dependency-path: "./app/pnpm-lock.yaml"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Run lint
-        run: pnpm lint
-
-      - name: Astro check
-        run: pnpm check
-
-      - name: Build project
-        run: pnpm build
+    uses: ./.github/workflows/ci-app-checks.yml
 
   validate-infra:
     name: Validate Infra
-    runs-on: ubuntu-latest
     needs: detect-changes
     if: needs.detect-changes.outputs.infra_changed == 'true'
-    env:
-      TF_IN_AUTOMATION: true
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.6.6
-          terraform_wrapper: false
-
-      - name: Terraform Format Check
-        run: terraform fmt -check -recursive infra
-
-      - name: Terraform Init Production
-        working-directory: ./infra/environments/production
-        run: terraform init -backend=false -input=false -lockfile=readonly
-
-      - name: Terraform Validate Production
-        working-directory: ./infra/environments/production
-        run: terraform validate -no-color
-
-      - name: Terraform Init Staging
-        working-directory: ./infra/environments/staging
-        run: terraform init -backend=false -input=false -lockfile=readonly
-
-      - name: Terraform Validate Staging
-        working-directory: ./infra/environments/staging
-        run: terraform validate -no-color
+    uses: ./.github/workflows/ci-infra-checks.yml
 
   validate-cv:
     name: Validate CV
-    runs-on: ubuntu-latest
     needs: detect-changes
     if: needs.detect-changes.outputs.cv_changed == 'true'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Validate CV file
-        run: |
-          set -euo pipefail
-
-          cv_file="app/public/cv/Leandro-Barbosa-DevOps-CV.pdf"
-
-          test -f "$cv_file"
-          test -s "$cv_file"
-
-          case "$cv_file" in
-            *.pdf) ;;
-            *) echo "CV file must be a PDF"; exit 1 ;;
-          esac
-
-          hash="$(sha256sum "$cv_file" | awk '{ print $1 }' | cut -c1-12)"
-          echo "CV hash: $hash"
+    uses: ./.github/workflows/ci-cv-checks.yml
 
   validate-pipeline:
     name: Validate Pipeline Changes

--- a/.github/workflows/ci-infra-checks.yml
+++ b/.github/workflows/ci-infra-checks.yml
@@ -1,0 +1,58 @@
+name: CI Infra Checks
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  terraform-fmt:
+    name: Terraform Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.6
+          terraform_wrapper: false
+
+      - name: Terraform Format Check
+        run: terraform fmt -check -recursive infra
+
+  terraform-validate:
+    name: Terraform Validate (${{ matrix.environment }})
+    needs: terraform-fmt
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - environment: production
+            working_directory: ./infra/environments/production
+          - environment: staging
+            working_directory: ./infra/environments/staging
+
+    env:
+      TF_IN_AUTOMATION: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.6
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        working-directory: ${{ matrix.working_directory }}
+        run: terraform init -backend=false -input=false -lockfile=readonly
+
+      - name: Terraform Validate
+        working-directory: ${{ matrix.working_directory }}
+        run: terraform validate -no-color


### PR DESCRIPTION
## Summary

Refactors the PR CI Gate by extracting app, infra and CV validations into reusable workflows.

Created:
- `.github/workflows/ci-app-checks.yml`
- `.github/workflows/ci-infra-checks.yml`
- `.github/workflows/ci-cv-checks.yml`

Updated:
- `.github/workflows/ci-gate.yml`

The `ci-gate.yml` workflow remains the PR orchestrator and still preserves the final required check:

- `CI Gate Result`.
- Infra checks validate `production` and `staging` root modules through a Terraform environment matrix.