### PR TITLE
fix(terraform): explicitly block S3 SSE-C encryption

### DIFF
--- a/infra/modules/site_stack/s3.tf
+++ b/infra/modules/site_stack/s3.tf
@@ -9,7 +9,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "portfolio_static_
 
   rule {
     bucket_key_enabled       = false
-    blocked_encryption_types = ["NONE"]
+    blocked_encryption_types = ["SSE-C"]
 
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"


### PR DESCRIPTION
Explicitly blocks SSE-C encryption for the static site S3 bucket by setting blocked_encryption_types = ["SSE-C"] in the shared site_stack module.

- Production already matches this desired configuration and returns no changes.
- Staging currently plans one in-place update to align with the hardened module configuration.