### PR TITLE
fix(terraform): include staging variable values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ pnpm-debug.log*
 *.tfvars
 *.tfvars.json
 !production.auto.tfvars
+!staging.auto.tfvars
 
 # Overrides
 override.tf

--- a/infra/environments/staging/staging.auto.tfvars
+++ b/infra/environments/staging/staging.auto.tfvars
@@ -1,0 +1,4 @@
+project_name = "portfolio"
+environment  = "staging"
+bucket_name  = "leandrodeobarbosa-portfolio-staging"
+domain_name  = "staging.leandrodeobarbosa.dev"


### PR DESCRIPTION
Adds the staging.auto.tfvars file required by the staging Terraform root module.

The previous staging apply failed because required non-sensitive variables were only available locally and were not versioned.

No sensitive values are included.